### PR TITLE
Change "bind to interface" null check

### DIFF
--- a/src/IO/StreamSocket.php
+++ b/src/IO/StreamSocket.php
@@ -103,7 +103,7 @@ class StreamSocket extends AbstractIO
         EventDispatcher $eventDispatcher = null
     ) {
         $context = null;
-        if (null !== $configuration->getValue('bind_to_interface')) {
+        if ('null' !== $configuration->getValue('bind_to_interface')) {
             $context = stream_context_create([
                 'socket' => [
                     'bindto' => $configuration->getValue('bind_to_interface')

--- a/src/IO/StreamSocket.php
+++ b/src/IO/StreamSocket.php
@@ -103,10 +103,11 @@ class StreamSocket extends AbstractIO
         EventDispatcher $eventDispatcher = null
     ) {
         $context = null;
-        if ('null' !== $configuration->getValue('bind_to_interface')) {
+        $bindTo = $configuration->getValue('bind_to_interface');
+        if (null !== $bindTo && 'null' !== $bindTo) {
             $context = stream_context_create([
                 'socket' => [
-                    'bindto' => $configuration->getValue('bind_to_interface')
+                    'bindto' => $bindTo
                 ]
             ]);
         }


### PR DESCRIPTION
This configuration setting has a default value of `"null"` (string) but is being compared against `null` (literal)

I opted for the least invasive fix as without knowing the codebase I'm guessing that changing the default could have unwanted side effects

This caused me errors when trying to connect, something along the lines of "failed to parse address null" when running [this function here](https://github.com/PlumTreeSystems/neo4j-bolt-php/blob/master/src/IO/StreamSocket.php#L214) because "context" was set to the string literal "null"

